### PR TITLE
大佬，发现您的项目引入了org.bouncycastle:bcprov-jdk15on@1.52组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.yu</groupId>
@@ -106,7 +104,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.52</version>
+            <version>1.66</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Bouncy Castle JCE Provider 数据伪造问题漏洞
缺陷组件：org.bouncycastle:bcprov-jdk15on@1.52
漏洞编号：CVE-2016-1000338
漏洞描述：Bouncy Castle JCE Provider是一款基于Java的加密包。
Bouncy Castle JCE Provider 1.55及之前版本存在安全漏洞，该漏洞源于DSA没有充分的验证对签名的ASN.1标准编码。攻击者可利用该漏洞向签名序列中注入其他的元素并保持签名有效，进而可能向已签名的框架中注入‘不可见’的数据。
影响范围：(∞, 1.56)
最小修复版本：1.66
缺陷组件引入路径：com.yu:auth-service@1.1.0->org.bouncycastle:bcprov-jdk15on@1.52
```
另外我运行这个项目时，IDE的安全插件提示还有67个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=peb638